### PR TITLE
Fix duplicate IDs

### DIFF
--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -23,14 +23,14 @@ NCard.todo(size="huge" hoverable)
       :todoIndex="index"
       :itemIndex="item.index"
       @delete="removeTodoItem"
-      :key="`todo-item-${item.id}-not-done`"
+      :key="`todo-${todo.id}-item-${item.id}-not-done`"
     )
     Item(
       v-for="item in completeItems"
       :todoIndex="index"
       :itemIndex="item.index"
       @delete="removeTodoItem"
-      :key="`todo-item-${item.id}-done`"
+      :key="`todo-${todo.id}-item-${item.id}-done`"
     )
   template(#footer)
     NSpace(justify="left")

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -91,6 +91,14 @@ export const getters = {
     });
     return yaml;
   },
+  nextTodoId: (state: State): number => 1 + state.todos.reduce(
+    (maxId: number, { id }) => (id > maxId ? id : maxId),
+    0,
+  ),
+  nextItemId: (state: State) => (index: number): number => 1 + state.todos[index].items.reduce(
+    (maxId: number, { id }) => (id > maxId ? id : maxId),
+    0,
+  ),
 };
 
 const load = (state: State, todos: Array<TodoList>): void => {

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -331,6 +331,12 @@ describe('store', () => {
       expect(nextTodoId(state)).to.equal(1);
     });
 
+    it('should return 1 if the max id is 0', () => {
+      const state = { todos: [{ title: 'foo', items: [], id: 0 }] };
+
+      expect(nextTodoId(state)).to.equal(1);
+    });
+
     it('should return 4 if the largest current id is 3', () => {
       const state = {
         todos: [
@@ -359,6 +365,20 @@ describe('store', () => {
           {
             title: 'foo',
             items: [],
+            id: 1,
+          },
+        ],
+      };
+
+      expect(nextItemId(state)(0)).to.equal(1);
+    });
+
+    it('should return 1 if there are the max id is 0', () => {
+      const state = {
+        todos: [
+          {
+            title: 'foo',
+            items: [{ description: 'a', id: 0, done: false }],
             id: 1,
           },
         ],

--- a/tests/unit/store/getters.spec.ts
+++ b/tests/unit/store/getters.spec.ts
@@ -322,4 +322,74 @@ describe('store', () => {
       });
     });
   });
+  describe('nextTodoId', () => {
+    const { nextTodoId } = getters;
+
+    it('should return 1 if there are no to-do lists', () => {
+      const state = { todos: [] };
+
+      expect(nextTodoId(state)).to.equal(1);
+    });
+
+    it('should return 4 if the largest current id is 3', () => {
+      const state = {
+        todos: [
+          {
+            title: 'foo',
+            items: [],
+            id: 1,
+          },
+          {
+            title: 'foo',
+            items: [],
+            id: 3,
+          },
+        ],
+      };
+
+      expect(nextTodoId(state)).to.equal(4);
+    });
+  });
+  describe('nextItemId', () => {
+    const { nextItemId } = getters;
+
+    it('should return 1 if there are no items', () => {
+      const state = {
+        todos: [
+          {
+            title: 'foo',
+            items: [],
+            id: 1,
+          },
+        ],
+      };
+
+      expect(nextItemId(state)(0)).to.equal(1);
+    });
+
+    it('should return 4 if the largest current id is 3', () => {
+      const state = {
+        todos: [
+          {
+            title: 'foo',
+            items: [
+              {
+                description: 'a',
+                done: false,
+                id: 1,
+              },
+              {
+                description: 'b',
+                done: false,
+                id: 3,
+              },
+            ],
+            id: 1,
+          },
+        ],
+      };
+
+      expect(nextItemId(state)(0)).to.equal(4);
+    });
+  });
 });


### PR DESCRIPTION
This PR should ensure that each ID for to-do lists and items are unique by analyzing existing IDs
and calculating what the next one should be. This *will not* fix existing issues with to-do lists,
but prevent new ones from occurring. A fix should be possible by exporting and re-importing to-do
list data.

Fixes #37
