### PR TITLE
Improve `numberedItems` performance

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -64,14 +64,19 @@ export const getters = {
       .map((item, index) => ({ index, ...item }))
       .filter(({ done }) => !done)
   ),
-  numberedItems: (state: State) => (todoIndex: number): Array<DuplicateItem> => {
-    const duplicateCounts: Map<string, number> = new Map();
-
-    return state.todos[todoIndex].items.map(({ description, ...attrs }) => {
-      const duplicates = (duplicateCounts.get(description) || 0);
-      duplicateCounts.set(description, duplicates + 1);
-      return { description, duplicates, ...attrs };
+  numberedItems: (state: State): NumberedItems => {
+    const numberedTodos = state.todos.map(({ items, ...todo }) => {
+      const duplicateCounts: Map<string, number> = new Map();
+      return {
+        ...todo,
+        items: items.map(({ description, ...item }) => {
+          const duplicates = duplicateCounts.get(description) || 0;
+          duplicateCounts.set(description, duplicates + 1);
+          return { description, duplicates, ...item };
+        }),
+      };
     });
+    return (todoIndex: number) => numberedTodos[todoIndex].items;
   },
   isItemValid: (state: State) => (todoIndex: number, itemIndex: number): boolean => (
     state.todos[todoIndex].items[itemIndex].description.length > 0


### PR DESCRIPTION
Instead calculating the duplicates with *every* call to `numberedItems`, calculate the duplicates for all to-do lists *once*, and return a callable that gets the list from the index.

Recreates #203

Can't hurt to have, even though it doesn't appear to be primary slowdown.