### PR TITLE
Allow deletion of duplicates

### DIFF
--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -23,6 +23,20 @@
         </template>
         This will delete the whole to-do list.
       </NPopconfirm>
+      <NDivider vertical />
+      <NPopover>
+        <template #trigger>
+          <NButton size="large" type="warning" secondary @click="clearDuplicates">
+            <template #icon>
+              <NIcon><FilterIcon /></NIcon>
+            </template>
+            Remove Duplicates
+          </NButton>
+        </template>
+        <NText type="warning">
+          Completed items will be kept over incomplete items
+        </NText>
+      </NPopover>
     </template>
     <NLayout class="todo-items">
       <NLayoutContent
@@ -67,13 +81,20 @@ import {
   NBackTop,
   NButton,
   NCard,
+  NDivider,
   NIcon,
   NLayout,
   NLayoutContent,
   NPopconfirm,
+  NPopover,
   NSpace,
+  NText,
 } from 'naive-ui';
-import { Add as AddIcon, Trash as DeleteIcon } from '@vicons/ionicons5';
+import {
+  Add as AddIcon,
+  Filter as FilterIcon,
+  Trash as DeleteIcon,
+} from '@vicons/ionicons5';
 import { useStore } from '@/store';
 import Item from './TodoItem.vue';
 import EditableText from './EditableText.vue';
@@ -108,6 +129,7 @@ const removeTodoItem = (itemIndex: number) => store.commit('removeTodoItem', {
   todoIndex: props.index,
   itemIndex,
 });
+const clearDuplicates = () => store.commit('clearDuplicates', props.index);
 </script>
 
 <style lang="stylus">

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -181,6 +181,23 @@ export const mutations = {
   }): void => {
     state.todos[todoIndex].items[itemIndex].done = false;
   },
+  clearDuplicates: (state: State, index: number): void => {
+    const found: Set<string> = new Set();
+
+    state.todos[index].items = state.todos[index].items.filter(({ description, done }) => {
+      const keep = !found.has(description);
+      if (done) {
+        found.add(description);
+      }
+      return keep;
+    });
+
+    state.todos[index].items = state.todos[index].items.filter(({ description, done }) => {
+      const keep = done || !found.has(description);
+      found.add(description);
+      return keep;
+    });
+  },
 };
 
 export const store = createStore<State>({

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -275,9 +275,11 @@ describe('store', () => {
                 { description: 'foo', done: false, id: 1 },
                 { description: 'bar', done: false, id: 2 },
                 { description: 'baz', done: true, id: 3 },
-                { description: 'bar', done: false, id: 4 },
-                { description: 'foo', done: true, id: 5 },
-                { description: 'baz', done: true, id: 6 },
+                { description: 'keep1', done: false, id: 4 },
+                { description: 'bar', done: false, id: 5 },
+                { description: 'foo', done: true, id: 6 },
+                { description: 'baz', done: true, id: 7 },
+                { description: 'keep2', done: true, id: 8 },
               ],
               id: 1,
             },
@@ -289,7 +291,9 @@ describe('store', () => {
         const expectedItems = [
           { description: 'bar', done: false, id: 2 },
           { description: 'baz', done: true, id: 3 },
-          { description: 'foo', done: true, id: 5 },
+          { description: 'keep1', done: false, id: 4 },
+          { description: 'foo', done: true, id: 6 },
+          { description: 'keep2', done: true, id: 8 },
         ];
 
         expect(state.todos[0].items).to.deep.equal(expectedItems);

--- a/tests/unit/store/mutations.spec.ts
+++ b/tests/unit/store/mutations.spec.ts
@@ -263,5 +263,37 @@ describe('store', () => {
         expect(done).to.be.false;
       });
     });
+    describe('clearDuplicates', () => {
+      const { clearDuplicates } = mutations;
+
+      it('should remove duplicates, prioritizing complete items', () => {
+        const state = {
+          todos: [
+            {
+              title: 'foo',
+              items: [
+                { description: 'foo', done: false, id: 1 },
+                { description: 'bar', done: false, id: 2 },
+                { description: 'baz', done: true, id: 3 },
+                { description: 'bar', done: false, id: 4 },
+                { description: 'foo', done: true, id: 5 },
+                { description: 'baz', done: true, id: 6 },
+              ],
+              id: 1,
+            },
+          ],
+        };
+
+        clearDuplicates(state, 0);
+
+        const expectedItems = [
+          { description: 'bar', done: false, id: 2 },
+          { description: 'baz', done: true, id: 3 },
+          { description: 'foo', done: true, id: 5 },
+        ];
+
+        expect(state.todos[0].items).to.deep.equal(expectedItems);
+      });
+    });
   });
 });


### PR DESCRIPTION
Adds a button that allows users to delete duplicates. Complete to-do
items take higher priority over incomplete items, so that at least one
completed to-do item will *always* remain after deleting duplicates.

Resolves #216
